### PR TITLE
Add new appendices on WebGL, contouring and LaTeX

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - flake8
   - geojson
   - geopandas
+  - jupyter_client<8
   - nbqa
   - notebook
   - pandas

--- a/notebooks/appendix_a_webgl.ipynb
+++ b/notebooks/appendix_a_webgl.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"float:left; border:none\">\n",
+    "   <tr style=\"border:none\">\n",
+    "       <td style=\"border:none\">\n",
+    "           <a href=\"https://bokeh.org/\" target=\"_blank\">\n",
+    "           <img\n",
+    "               src=\"assets/bokeh-transparent.png\"\n",
+    "               style=\"width:50px\"\n",
+    "           >\n",
+    "           </a>\n",
+    "       </td>\n",
+    "       <td style=\"border:none\">\n",
+    "           <h1>Bokeh Tutorial</h1>\n",
+    "       </td>\n",
+    "   </tr>\n",
+    "</table>\n",
+    "\n",
+    "<div style=\"float:right;\"><a href=\"TOC.ipynb\" target=\"_blank\">Table of contents</a><br><h2>Appendix A: WebGL</h2></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bokeh draws graphics on web pages using HTML Canvas by default. For larger datasets there is another option which is to use WebGL. This provides hardware acceleration of graphics if you have a processor or graphics cards that supports it.\n",
+    "\n",
+    "Let's look at an example that compares Canvas and WebGL side-by-side, using a ``hex_tile`` plot which is 2D histogram using hexagons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.io import output_notebook, show\n",
+    "from bokeh.layouts import row\n",
+    "from bokeh.plotting import figure\n",
+    "from bokeh.transform import linear_cmap\n",
+    "from bokeh.util.hex import hexbin\n",
+    "import numpy as np\n",
+    "\n",
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 5_000_000\n",
+    "x = np.random.standard_normal(n)\n",
+    "y = np.random.standard_normal(n)\n",
+    "\n",
+    "bins = hexbin(x, y, 0.01)\n",
+    "print(f\"Number of hexagons: {len(bins):,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ps = []\n",
+    "for backend in ([\"canvas\", \"webgl\"]):\n",
+    "    p = figure(title=backend, tools=\"pan, wheel_zoom, box_select, reset\",\n",
+    "               output_backend=backend, width=450, height=450)\n",
+    "    p.grid.visible = False\n",
+    "    p.hex_tile(q=\"q\", r=\"r\", size=1, line_color=None, source=bins,\n",
+    "               fill_color=linear_cmap('counts', 'Plasma256', 0, max(bins.counts)))\n",
+    "    ps.append(p)\n",
+    "show(row(ps))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Interact with the plots to see how much faster WebGL is in your browser. Things to try:\n",
+    "\n",
+    "* Pan using the mouse\n",
+    "* Zoom using the mouse wheel\n",
+    "* Select a region of the plot such as one quarter of it, and repeat the pan and zoom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How much faster is WebGL?\n",
+    "\n",
+    "It is difficult to generalize, it depends on the graphics processing hardware you have available. Try it out to see.\n",
+    "\n",
+    "\n",
+    "### How do you enable WebGL?\n",
+    "\n",
+    "By using the ``output_backend=\"webgl\"`` keyword argument when creating a ``figure``.\n",
+    "\n",
+    "\n",
+    "### What glyphs are supported by WebGL?\n",
+    "\n",
+    "Not all Bokeh glyphs have WebGL support yet, but we are adding more all the time. If you have chosen to use WebGL then Bokeh will use WebGL for the glyphs that it can, and drop back to using Canvas for those not yet supported.\n",
+    "\n",
+    "For a full list of glyphs supported using WebGL see the [latest Bokeh documentation](https://docs.bokeh.org/en/latest/docs/user_guide/output/webgl.html#supported-glyphs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0494a81e5f69860dcb844ce8e12eb9c88a7e813ddbfb0fbade72137f5ce45437"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/appendix_a_webgl.ipynb
+++ b/notebooks/appendix_a_webgl.ipynb
@@ -71,7 +71,7 @@
     "ps = []\n",
     "for backend in ([\"canvas\", \"webgl\"]):\n",
     "    p = figure(title=backend, tools=\"pan, wheel_zoom, box_select, reset\",\n",
-    "               output_backend=backend, width=450, height=450)\n",
+    "               output_backend=backend, width=450, height=450, lod_threshold=None)\n",
     "    p.grid.visible = False\n",
     "    p.hex_tile(q=\"q\", r=\"r\", size=1, line_color=None, source=bins,\n",
     "               fill_color=linear_cmap('counts', 'Plasma256', 0, max(bins.counts)))\n",

--- a/notebooks/appendix_b_contour_plots.ipynb
+++ b/notebooks/appendix_b_contour_plots.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "# Data to contour is the sum of two Gaussian functions.\n",
     "x, y = np.meshgrid(np.linspace(0, 3, 40), np.linspace(0, 2, 30))\n",
-    "z = 1.3*np.exp(-2.5*((x-1.3)**2 + (y-0.8)**2)) - 1.2*np.exp(-2*((x-1.8)**2 + (y-1.3)**2))"
+    "z = 1.3 * np.exp(-2.5 * ((x - 1.3) ** 2 + (y - 0.8) ** 2)) - 1.2 * np.exp(-2 * ((x - 1.8) ** 2 + (y - 1.3) ** 2))"
    ]
   },
   {

--- a/notebooks/appendix_b_contour_plots.ipynb
+++ b/notebooks/appendix_b_contour_plots.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"float:left; border:none\">\n",
+    "   <tr style=\"border:none\">\n",
+    "       <td style=\"border:none\">\n",
+    "           <a href=\"https://bokeh.org/\" target=\"_blank\">\n",
+    "           <img\n",
+    "               src=\"assets/bokeh-transparent.png\"\n",
+    "               style=\"width:50px\"\n",
+    "           >\n",
+    "           </a>\n",
+    "       </td>\n",
+    "       <td style=\"border:none\">\n",
+    "           <h1>Bokeh Tutorial</h1>\n",
+    "       </td>\n",
+    "   </tr>\n",
+    "</table>\n",
+    "\n",
+    "<div style=\"float:right;\"><a href=\"TOC.ipynb\" target=\"_blank\">Table of contents</a><br><h2>Appendix B: Contour plots</h2></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bokeh includes contour plots. You can plot both contour lines and filled regions between contour lines with a single ``contour`` call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.io import output_notebook, show\n",
+    "from bokeh.palettes import Sunset\n",
+    "from bokeh.plotting import figure\n",
+    "import numpy as np\n",
+    "\n",
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Data to contour is the sum of two Gaussian functions.\n",
+    "x, y = np.meshgrid(np.linspace(0, 3, 40), np.linspace(0, 2, 30))\n",
+    "z = 1.3*np.exp(-2.5*((x-1.3)**2 + (y-0.8)**2)) - 1.2*np.exp(-2*((x-1.8)**2 + (y-1.3)**2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = figure(width=700, height=400, x_range=(0, 3), y_range=(0, 2))\n",
+    "\n",
+    "levels = np.linspace(-1, 1, 9)\n",
+    "contour_renderer = p.contour(x, y, z, levels, fill_color=Sunset, line_color=\"black\")\n",
+    "\n",
+    "colorbar = contour_renderer.construct_color_bar()\n",
+    "p.add_layout(colorbar, \"right\")\n",
+    "\n",
+    "show(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Contour lines are calculated and displayed if ``line_color`` is something other than ``None``, and filled contour regions are calculated and displayed if ``fill_color`` is something other than ``None``.\n",
+    "\n",
+    "Visual properties (``line``, ``fill`` and ``hatch``) can be specified as scalar or vector properties as usual, such as ``line_width`` and ``hatch_pattern``.\n",
+    "\n",
+    "For more information see the Contour plots [topic guide](https://docs.bokeh.org/en/latest/docs/user_guide/topics/contour.html) in the latest Bokeh documentation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0494a81e5f69860dcb844ce8e12eb9c88a7e813ddbfb0fbade72137f5ce45437"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/appendix_c_latex.ipynb
+++ b/notebooks/appendix_c_latex.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"float:left; border:none\">\n",
+    "   <tr style=\"border:none\">\n",
+    "       <td style=\"border:none\">\n",
+    "           <a href=\"https://bokeh.org/\" target=\"_blank\">\n",
+    "           <img\n",
+    "               src=\"assets/bokeh-transparent.png\"\n",
+    "               style=\"width:50px\"\n",
+    "           >\n",
+    "           </a>\n",
+    "       </td>\n",
+    "       <td style=\"border:none\">\n",
+    "           <h1>Bokeh Tutorial</h1>\n",
+    "       </td>\n",
+    "   </tr>\n",
+    "</table>\n",
+    "\n",
+    "<div style=\"float:right;\"><a href=\"TOC.ipynb\" target=\"_blank\">Table of contents</a><br><h2>Appendix C: LaTeX</h2></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bokeh supports LaTeX equations in a number of different elements.\n",
+    "\n",
+    "This is based on the [Bessel equation example](https://docs.bokeh.org/en/latest/docs/examples/styling/mathtext/latex_bessel.html) in the Bokeh documentation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.io import output_notebook\n",
+    "from bokeh.models import ColorBar, CustomJS, Div, FixedTicker, Label, LinearColorMapper, Paragraph, Slider\n",
+    "from bokeh.palettes import TolPRGn, PiYG\n",
+    "from bokeh.plotting import column, figure, show\n",
+    "import numpy as np\n",
+    "from scipy.special import jv\n",
+    "\n",
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = figure(\n",
+    "    width=700, height=450,\n",
+    "    title=r\"$$\\text{Bessel functions of the first kind: } J_\\alpha(x) = \\sum_{m=0}^{\\infty}\"\n",
+    "          r\"\\frac{(-1)^m}{m!\\:\\Gamma(m+\\alpha+1)} \\left(\\frac{x}{2}\\right)^{2m+\\alpha}$$\",\n",
+    ")\n",
+    "p.x_range.range_padding = 0\n",
+    "p.xaxis.axis_label = r\"$$x$$\"\n",
+    "p.yaxis.axis_label = r\"$$J_\\alpha(x)$$\"\n",
+    "p.title.text_font_size = \"14px\"\n",
+    "\n",
+    "x = np.linspace(0.0, 14.0, 100)\n",
+    "\n",
+    "for i, (xlabel, ylabel) in enumerate(zip([0.5, 1.6, 2.8, 4.2], [0.95, 0.6, 0.5, 0.45])):\n",
+    "    p.line(x, jv(i, x), line_width=3, color=PiYG[4][i])\n",
+    "    p.add_layout(Label(text=r\"$$J_\" + str(i) + \"(x)$$\", x=xlabel, y=ylabel))\n",
+    "\n",
+    "show(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note:\n",
+    "\n",
+    "- Use of standard LaTeX delimeters of ``$$``. Other options are available.\n",
+    "- Use raw Python strings e.g. ``r\"$$\\alpha$$\"`` so that backslashes are interpreted as normal characters rather than control sequences. \n",
+    "- ``Div`` and ``Paragraph`` accept LaTeX for just part of their contents, but for all other elements the whole contents must be LaTeX.\n",
+    "    - To put normal text in a LaTeX string use ``\\text{...}``.\n",
+    "    - We are actively working on improvements in this area.\n",
+    "\n",
+    "\n",
+    "## Where can LaTeX be used?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = figure(width=500, height=400)\n",
+    "p.circle(1, 1, size=0)\n",
+    "\n",
+    "p.title = r\"$$\\LaTeX \\text{ figure title}$$\"\n",
+    "p.axis.axis_label = r\"$$\\LaTeX \\text{ axis label}$$\"\n",
+    "p.axis.ticker = FixedTicker(ticks=[1])\n",
+    "p.axis.major_label_overrides = {1: r\"$$\\LaTeX \\text{ tick label}$$\"}\n",
+    "p.yaxis.major_label_orientation = \"vertical\"\n",
+    "p.add_layout(Label(text=r\"$$\\LaTeX \\text{ label}$$\", text_font_size=\"26px\",\n",
+    "                   angle=0.4, text_baseline=\"middle\", text_align=\"center\", x=1, y=1))\n",
+    "\n",
+    "slider = Slider(start=0, end=100, value=50, step=1, title=r\"$$\\LaTeX \\text{ slider}$$\")\n",
+    "div = Div(text=r\"$$\\LaTeX$$ div\")\n",
+    "paragraph = Paragraph(text=r\"$$\\LaTeX$$ paragraph\")\n",
+    "\n",
+    "color_mapper = LinearColorMapper(palette=PiYG[8])\n",
+    "colorbar = ColorBar(color_mapper=color_mapper, title=r\"$$\\LaTeX \\text{ colorbar title}$$\")\n",
+    "p.add_layout(colorbar, \"right\")\n",
+    "\n",
+    "show(column(p, slider, div, paragraph))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For further information see the [LaTeX section](https://docs.bokeh.org/en/latest/docs/user_guide/styling/mathtext.html#latex) in the User Guide."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0494a81e5f69860dcb844ce8e12eb9c88a7e813ddbfb0fbade72137f5ce45437"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adds three new small appendices on WebGL, contour plots and LaTeX, in preparation for the SciPy tutorial.

I haven't yet added links from the main notebooks to these appendices.

Also pinned `jupyter_client<8` due to a known problem in the `jupyter` ecosystem (see holoviz/holoviews#5699). We may be able to relax this prior to presenting the tutorial.