### PR TITLE
Remove black format pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,5 @@ repos:
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.5.3
   hooks:
-   - id: nbqa-black
-     args: [--diff, --line-length=256]
-     additional_dependencies: [black==22.10.0]
    - id: nbqa-flake8
      additional_dependencies: [flake8==6.0.0]

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ environment):
 pre-commit install
 ```
 
-This way, some basic linting and formatting checks will be run on your code before
-you commit it.
+This way, some basic linting will be run on your code before you commit it.
+
+For consistency, we ask that you generally follow the
+[Black code style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
+wherever possible.
 
 ### Making changes
 


### PR DESCRIPTION
cc @ianthomas23 @pavithraes @tcmetzger 

Submitted for consideration. I am dubious of `black` formatting in general these days, and especially in notebooks. But I think as @ianthomas23 has pointed out we should not sacrifice accepted mathematical notation just to appease a formatter.