### PR TITLE
Better equation format

### DIFF
--- a/notebooks/14_next_steps.ipynb
+++ b/notebooks/14_next_steps.ipynb
@@ -20,7 +20,7 @@
     "   </tr>\n",
     "</table>\n",
     "\n",
-    "<div style=\"float:right;\"><a href=\"TOC.ipynb\" target=\"_blank\">Table of contents</a><br><h2>15 Next steps</h2></div>"
+    "<div style=\"float:right;\"><a href=\"TOC.ipynb\" target=\"_blank\">Table of contents</a><br><h2>14 Next steps</h2></div>"
    ]
   },
   {

--- a/notebooks/appendix_b_contour_plots.ipynb
+++ b/notebooks/appendix_b_contour_plots.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "# Data to contour is the sum of two Gaussian functions.\n",
     "x, y = np.meshgrid(np.linspace(0, 3, 40), np.linspace(0, 2, 30))\n",
-    "z = 1.3 * np.exp(-2.5 * ((x - 1.3) ** 2 + (y - 0.8) ** 2)) - 1.2 * np.exp(-2 * ((x - 1.8) ** 2 + (y - 1.3) ** 2))"
+    "z = 1.3*np.exp(-2.5*((x-1.3)**2 + (y-0.8)**2)) - 1.2*np.exp(-2*((x-1.8)**2 + (y-1.3)**2))"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ line-length = 256
 
 [tool.nbqa.addopts]
 flake8 = [
-    "--ignore=E501,E402,E266,F401"
+    "--ignore=E501,E402,E226,F401"
 ]


### PR DESCRIPTION
Small changes:

1. Updated the format of the equation in the LaTeX appendix.
2. Tell flake8 to ignore requirement for spaces around operators.
3. Number in title of notebook 14 corrected.

We should switch from flake8 to ruff when we have more time available.