### PR TITLE
Update RangeTool example

### DIFF
--- a/notebooks/08_plot_tools.ipynb
+++ b/notebooks/08_plot_tools.ipynb
@@ -433,11 +433,6 @@
     "range_tool.overlay.fill_alpha = 0.3\n",
     "range_tool.overlay.inverted = True\n",
     "range_tool.overlay.use_handles = True\n",
-    "range_tool.overlay.handles[\"all\"].hover_fill_color = \"orange\"\n",
-    "range_tool.overlay.handles[\"all\"].hover_fill_alpha = 0.9\n",
-    "range_tool.overlay.handles[\"all\"].hover_line_alpha = 0\n",
-    "range_tool.overlay.handles[\"all\"].fill_alpha = 0.1\n",
-    "range_tool.overlay.handles[\"all\"].line_alpha = 0.1\n",
     "minimap.add_tools(range_tool)\n",
     "\n",
     "show(column(detailed_plot, minimap))"


### PR DESCRIPTION
the current example produces an error:

![image](https://github.com/bokeh/tutorial/assets/39711796/0701e487-951a-4197-a76f-2c8d93282d23)

Since this might be a bit too much detail for the tutorial anyways, I'd just remove this part of the code!

cc @droumis 