### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Contributing to this tutorial repository works similarly to
 
 Once you have created a pull request, a member of the Bokeh core team will begin reviewing your pull request and may request changes or additions. If so, they will help you along the way with any questions you may have.
 
-## SciPy US 2023
+## Previous presentations
 
-This tutorial was presented live during the SciPy 2023 conference. The state of the repository, as presented, can be accessed through the designated git tag, available [here](https://github.com/bokeh/tutorial/releases/tag/SciPy2023).
-
-The tutorial presentation is accessible on YouTube via the following link: https://youtu.be/G0Yc3ck4lC8?si=ZGqatTPnZBwjtdXO
+* SciPy 2024: [Material](https://github.com/bokeh/tutorial/releases/tag/SciPy2024)
+* SciPy 2023: [Video](https://youtu.be/G0Yc3ck4lC8?si=ZGqatTPnZBwjtdXO), [Material](https://github.com/bokeh/tutorial/releases/tag/SciPy2023)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
 # Bokeh tutorial notebooks
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bokeh/tutorial/main?filepath=notebooks%2F01_introduction.ipynb)
-
-This repository contains a series of Jupyter notebooks.
-These notebooks are available as an interactive tutorial at
-https://mybinder.org/v2/gh/bokeh/tutorial/main?filepath=notebooks%2F01_introduction.ipynb
-
-To learn about Bokeh, please use the tutorial on [mybinder.org](https://mybinder.org/v2/gh/bokeh/tutorial/main?filepath=notebooks%2F01_introduction.ipynb).
-
-You can also [install and run the notebooks on a local machine](#local-setup).
-This is helpful if you can't access mybinder.org, or if you want to
-[contribute to this tutorial](#contributing-to-this-tutorial).
+You can [install and run the notebooks on a local machine](#local-setup).
 
 ## Setup for SciPy US 2024
 
@@ -65,21 +55,14 @@ Follow these steps to run the tutorial notebooks on your local machine:
     conda activate bk-tutorial
     ```
 
-5. Before opening the tutorial notebooks, you need to **install the Bokeh sampledata**.
-    Make sure the ``bk-tutorial`` environment is activated, then run the following command:
-
-    ```bash
-    bokeh sampledata
-    ```
-
-6. From inside the  ``bk-tutorial`` environment, you can now **start the Jupyter
+5. From inside the  ``bk-tutorial`` environment, you can now **start the Jupyter
     notebook server**:
 
     ```bash
     jupyter notebook
     ```
 
-7. After opening Jupyter notebooks in a browser, go to the folder `notebooks`.
+6. After opening Jupyter notebooks in a browser, go to the folder `notebooks`.
     **Open the first notebook in this folder**. It is called
     `01_introduction.ipynb`.
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,10 @@
 # Bokeh tutorial notebooks
 
-You can [install and run the notebooks on a local machine](#local-setup).
-
-## Setup for SciPy US 2024
-
-This tutorial will be presented at the SciPy 2024 conference, where you can use Nebari (JupterHub) hosted at [scipy.quansight.dev](https://scipy.quansight.dev/) to follow along.
-
-Follow [this participant's guide](https://docs.google.com/document/d/11YWMZKW6Y4tXnMs3Jekc1S7BQWTR6THZazDaq3WoNxw/edit?usp=sharing) to register, sign-in, and download the tutorial materials.
-
-In the `tutorials/tutorial` folder that's created with all material, navigate to the `notebooks` folder, and open `01_introduction.ipynb`.
-
-The environment for this tutorial is `scipy-scipy-interactive-dataviz-bokeh`, and it is automatically selected for you.
-
-## Previous presentations
-
-### SciPy US 2023
-
-This tutorial was presented live during the SciPy 2023 conference. The state of the repository, as presented, can be accessed through the designated git tag, available [here](https://github.com/bokeh/tutorial/releases/tag/SciPy2023).
-
-Additionally, the tutorial presentation is accessible on YouTube via the following link: https://youtu.be/G0Yc3ck4lC8?si=ZGqatTPnZBwjtdXO
-
-## Local setup
+## Setup and run the tutorials
 
 Follow these steps to run the tutorial notebooks on your local machine:
 
-1. To run the tutorial locally, first **clone** this repository to your local machine.
+1. Start by **cloning** this repository to your local machine.
     For example:
 
     ```bash
@@ -92,3 +72,9 @@ Contributing to this tutorial repository works similarly to
 2. Make PR and link it to the issue you created
 
 Once you have created a pull request, a member of the Bokeh core team will begin reviewing your pull request and may request changes or additions. If so, they will help you along the way with any questions you may have.
+
+## SciPy US 2023
+
+This tutorial was presented live during the SciPy 2023 conference. The state of the repository, as presented, can be accessed through the designated git tag, available [here](https://github.com/bokeh/tutorial/releases/tag/SciPy2023).
+
+The tutorial presentation is accessible on YouTube via the following link: https://youtu.be/G0Yc3ck4lC8?si=ZGqatTPnZBwjtdXO


### PR DESCRIPTION
Quick edits to remove mybinder info, since the site just finally appears to be fully offline (500 errors even from https://mybinder.org/)

Also removes the bits about `bokeh sampledata`.

Would probably be nice to collapse old conf sections into a short list with just video and repo tag links since the signup etc info is not useful in an ongoing way. But I'll leave that for others/later. 